### PR TITLE
Beginning of shell options (#18)

### DIFF
--- a/include/backend.h
+++ b/include/backend.h
@@ -106,6 +106,14 @@ int psh_backend_getuid(void);
  */
 int psh_backend_chdir(char *);
 
+/** POSIX-style getopt.
+ *
+ * @param argc argc passsed to main()
+ * @param argv argv passsed to main()
+ * @param optstring Options specification.
+ */
+int psh_backend_getopt(int argc, char **argv, const char *optstring);
+
 /** Run a command.
  *
  * @param command The command struct about command details.

--- a/include/backend.h
+++ b/include/backend.h
@@ -111,6 +111,6 @@ int psh_backend_chdir(char *);
  * @param command The command struct about command details.
  * @return Zero if succeeded.
  */
-int psh_backend_do_run(struct command *command);
+int psh_backend_do_run(struct command *command, char __verbose);
 
 #endif /* _PSH_BACKEND_H*/

--- a/src/backends/posix/posix.c
+++ b/src/backends/posix/posix.c
@@ -175,30 +175,33 @@ static int redir_spawnve(struct redirect *arginfo, char *cmd, char **argv,
     return pid;
 }
 
-int psh_backend_do_run(struct command *arginfo)
+int psh_backend_do_run(struct command *arginfo, char verbose)
 {
     struct command *info = arginfo;
-    int i = 0;
-    printf("--**--\nstub!\nflags won't be read\n");
-    printf("info position: %p\n", (void *)arginfo);
-    while (++i)
-    {
-        int j;
-        printf("part %d:\n"
-               "command: %s\n"
-               "params:\n",
-               i, info->argv[0]);
-        for (j = 0; info->argv[j]; ++j)
-            printf("%s\n", info->argv[j]);
-        printf("flag: %d\n", info->flag);
-        printf("redir type: %d\n",
-               (info->rlist != NULL) ? info->rlist->type : 0);
 
-        if (info->next == NULL)
-            break;
-        info = info->next;
+    if(verbose){
+        int i = 0;
+        printf("--**--\nstub!\nflags won't be read\n");
+        printf("info position: %p\n", (void *)arginfo);
+        while (++i)
+        {
+            int j;
+            printf("part %d:\n"
+                   "command: %s\n"
+                   "params:\n",
+                   i, info->argv[0]);
+            for (j = 0; info->argv[j]; ++j)
+                printf("%s\n", info->argv[j]);
+            printf("flag: %d\n", info->flag);
+            printf("redir type: %d\n",
+                   (info->rlist != NULL) ? info->rlist->type : 0);
+
+            if (info->next == NULL)
+                break;
+            info = info->next;
+        }
+        printf("--*END*--\n");
     }
-    printf("--*END*--\n");
     if ((ChdPid = fork()) != 0) /*shell*/
     {
         waitpid(ChdPid, &last_command_status, 0); /*wait command1*/

--- a/src/backends/posix/posix.c
+++ b/src/backends/posix/posix.c
@@ -128,6 +128,11 @@ int psh_backend_setenv(const char *name, const char *value, int overwrite)
     return setenv(name, value, overwrite);
 }
 
+int psh_backend_getopt(int argc, char **argv, const char *optstring)
+{
+    return getopt(argc, argv, optstring);
+}
+
 static int redir_spawnve(struct redirect *arginfo, char *cmd, char **argv,
                          char **env)
 {
@@ -179,8 +184,9 @@ int psh_backend_do_run(struct command *arginfo, char verbose)
 {
     struct command *info = arginfo;
 
-    //verbose can be 0 or 1, if is only true when verbose == 1
-    if(verbose){
+    /* verbose can be 0 or 1, if is only true when verbose == 1 */
+    if (verbose)
+    {
         int i = 0;
         printf("--**--\nstub!\nflags won't be read\n");
         printf("info position: %p\n", (void *)arginfo);

--- a/src/backends/posix/posix.c
+++ b/src/backends/posix/posix.c
@@ -179,6 +179,7 @@ int psh_backend_do_run(struct command *arginfo, char verbose)
 {
     struct command *info = arginfo;
 
+    //verbose can be 0 or 1, if is only true when verbose == 1
     if(verbose){
         int i = 0;
         printf("--**--\nstub!\nflags won't be read\n");

--- a/src/builtins/echo.c
+++ b/src/builtins/echo.c
@@ -56,7 +56,8 @@ int builtin_echo(int argc, char **argv)
                     }
                     return 0;
                 }
-            default: {
+            default:
+            {
                 int cnt = 1;
                 printf("%s", argv[cnt]);
                 while (argv[++cnt] != NULL)

--- a/src/builtins/history.c
+++ b/src/builtins/history.c
@@ -184,7 +184,8 @@ int builtin_history(int argc, char **argv)
         }
     }
     else
-    noopts : {
+    noopts:
+    {
         HIST_ENTRY **histlist;
         int i;
 

--- a/src/main.c
+++ b/src/main.c
@@ -46,13 +46,14 @@ char *argv0;
 
 int main(int argc, char **argv)
 {
-
     char arg;
     char verbose = 0;
 
+    //goes through every arg and checks
     while((arg = getopt(argc, argv, ":v")) != -1){
         switch(arg){
 
+            //if -v is present set verbose to 1
             case 'v':
                 verbose = 1;
                 break;

--- a/src/main.c
+++ b/src/main.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv)
 {
 
     char arg;
-    char verbose;
+    char verbose = 0;
 
     while((arg = getopt(argc, argv, ":v")) != -1){
         switch(arg){
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
         }
         else
         {
-            //psh_backend_do_run(cmd);
+            psh_backend_do_run(cmd, verbose);
         }
         free_command(cmd);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 /* Some evil implementations include no stdio.h is history.h */
 #ifdef HAVE_READLINE_HISTORY_H
@@ -45,6 +46,20 @@ char *argv0;
 
 int main(int argc, char **argv)
 {
+
+    char arg;
+    char verbose;
+
+    while((arg = getopt(argc, argv, ":v")) != -1){
+        switch(arg){
+
+            case 'v':
+                verbose = 1;
+                break;
+
+        }
+    }
+
     builtin_function bltin;
     int stat;
     struct command *cmd = NULL;
@@ -83,14 +98,15 @@ int main(int argc, char **argv)
 
         /* Temporary work-around. #2 #5 #9 TODO, invoke bltin in
          * psh_backend_do_run() */
-        bltin = find_builtin(cmd->argv[0]);
+        
+		bltin = find_builtin(cmd->argv[0]);
         if (bltin)
         {
             last_command_status = (*bltin)(get_argc(cmd->argv), cmd->argv);
         }
         else
         {
-            psh_backend_do_run(cmd);
+            //psh_backend_do_run(cmd);
         }
         free_command(cmd);
     }


### PR DESCRIPTION
Hey,

I have added a small code piece that allows you to get arguments really easy and also I implemented a verbose flag `-v`.
Use this flag like `src/psh -v` if flag is given psh outputs an extra section with usefull information.
I have tested it a little bit, it seems to work perfectly fine and it allows us to introduce new flags really easily
The function I used is in `unistd.h` and is called [getopt](https://www.tutorialspoint.com/getopt-function-in-c-to-parse-command-line-arguments)