### PR TITLE
Implement long option (#18) and fix small bugs

### DIFF
--- a/include/args.h
+++ b/include/args.h
@@ -1,6 +1,6 @@
 #ifndef ARGS_H_
 #define ARGS_H_
 
-void setargs(int argc, char **argv, const char *optstring, char *argv0);
+void parse_shell_args(int argc, char **argv);
 
 #endif

--- a/include/args.h
+++ b/include/args.h
@@ -1,6 +1,7 @@
 /** @file psh/include/args.h - @brief psh argument parser */
 /*
     Copyright 2020 Manuel Bertele
+    Copyright 2020 Zhang Maiyun
 
     This file is part of Psh, P shell.
 
@@ -18,12 +19,11 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef _PSH_ARGS_H_
 #define _PSH_ARGS_H_
 
 /** Parse shell parameters and set appropriate variables.
- * 
+ *
  * @param argc The first parameter to main()
  * @param argv The second parameter to main()
  */

--- a/include/args.h
+++ b/include/args.h
@@ -1,5 +1,5 @@
+/** @file psh/include/args.h - @brief psh argument parser */
 /*
-    psh/include/args.h - psh argument control
     Copyright 2020 Manuel Bertele
 
     This file is part of Psh, P shell.
@@ -19,9 +19,14 @@
 */
 
 
-#ifndef _ARGS_H_
-#define _ARGS_H_
+#ifndef _PSH_ARGS_H_
+#define _PSH_ARGS_H_
 
+/** Parse shell parameters and set appropriate variables.
+ * 
+ * @param argc The first parameter to main()
+ * @param argv The second parameter to main()
+ */
 void parse_shell_args(int argc, char **argv);
 
 #endif

--- a/include/args.h
+++ b/include/args.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef ARGS_H_
-#define ARGS_H_
+#ifndef _ARGS_H_
+#define _ARGS_H_
 
 void parse_shell_args(int argc, char **argv);
 

--- a/include/args.h
+++ b/include/args.h
@@ -1,3 +1,24 @@
+/*
+    psh/include/args.h - psh argument control
+    Copyright 2020 Manuel Bertele
+
+    This file is part of Psh, P shell.
+
+    Psh is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Psh is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
 #ifndef ARGS_H_
 #define ARGS_H_
 

--- a/include/args.h
+++ b/include/args.h
@@ -1,0 +1,6 @@
+#ifndef ARGS_H_
+#define ARGS_H_
+
+void setargs(int argc, char **argv, const char *optstring, char *argv0);
+
+#endif

--- a/include/backend.h
+++ b/include/backend.h
@@ -119,6 +119,6 @@ int psh_backend_getopt(int argc, char **argv, const char *optstring);
  * @param command The command struct about command details.
  * @return Zero if succeeded.
  */
-int psh_backend_do_run(struct command *command, char __verbose);
+int psh_backend_do_run(struct command *command);
 
 #endif /* _PSH_BACKEND_H*/

--- a/lib/util.c
+++ b/lib/util.c
@@ -47,10 +47,10 @@ char *psh_fgets(char *prompt, FILE *fp)
     if (fp == NULL)
         return NULL;
     if (fp == stdin)
-	{
+    {
         printf("%s", prompt);
-		fflush(stdout);
-	}
+        fflush(stdout);
+    }
     {
         size_t charcount = 0, nowhave = 256;
         int ch;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@ include(GNUInstallDirs)
 
 include("${CMAKE_SOURCE_DIR}/cmake/select_backend.cmake")
 
-add_executable (psh builtins.c command.c filpinfo.c input.c main.c parser.c prompts.c ${CMAKE_BINARY_DIR}/select_backend.c util.c variable.c builtins/builtin.c builtins/cd.c builtins/echo.c builtins/exit.c builtins/history.c builtins/pwd.c builtins/true.c)
+add_executable (psh builtins.c command.c filpinfo.c input.c main.c parser.c prompts.c ${CMAKE_BINARY_DIR}/select_backend.c util.c variable.c builtins/builtin.c builtins/cd.c builtins/echo.c builtins/exit.c builtins/history.c builtins/pwd.c builtins/true.c args.c)
 
 include_directories(../include)
 target_link_libraries(psh libpsh)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = foreign
 bin_PROGRAMS = psh
-psh_SOURCES = builtins.c command.c filpinfo.c input.c main.c parser.c \
+psh_SOURCES = builtins.c command.c filpinfo.c input.c main.c parser.c args.c \
 			  prompts.c util.c variable.c builtins/builtin.c builtins/cd.c \
 			  builtins/echo.c builtins/exec.c builtins/exit.c \
 			  builtins/history.c builtins/pwd.c builtins/true.c
@@ -9,8 +9,9 @@ noinst_HEADERS = $(top_srcdir)/include/backend.h $(top_srcdir)/include/builtin.h
 				 $(top_srcdir)/include/command.h $(top_srcdir)/include/filpinfo.h \
 				 $(top_srcdir)/include/input.h $(top_srcdir)/include/prompts.h \
 				 $(top_srcdir)/include/psh.h $(top_srcdir)/include/token.h \
-				 $(top_srcdir)/include/util.h $(top_srcdir)/include/variable.h
-psh_LDADD = $(top_srcdir)/lib/libpsh.a
+				 $(top_srcdir)/include/util.h $(top_srcdir)/include/variable.h \
+				 $(top_srcdir)/include/args.h
+psh_LDADD = ../lib/libpsh.a
 
 if POSIX
 psh_SOURCES += backends/posix/posix.c

--- a/src/args.c
+++ b/src/args.c
@@ -1,0 +1,33 @@
+#include <unistd.h>
+
+#include "libpsh/util.h"
+#include "backend.h"
+
+/* Set variable thats globally avaliable */
+int verbose = 0;
+
+void setargs(int argc, char **argv, const char *optstring, char *argv0)
+{
+
+    int arg;
+
+    /* Parse shell options */
+    while ((arg = psh_backend_getopt(argc, argv, ":v")) != -1)
+    {
+        switch (arg)
+        {
+            /* Verbose flag */
+            case 'v':
+                verbose = 1;
+                break;
+            case ':':
+                OUT2E("%s: option requires an argument\n", argv0);
+                break;
+            case '?':
+            default:
+                OUT2E("%s: unknown option -%c\n", argv0, optopt);
+                break;
+        }
+    }
+
+}

--- a/src/args.c
+++ b/src/args.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+static void print_help_info();
 static void print_version_exit();
 
 /* Set variable thats globally avaliable */
@@ -36,12 +37,14 @@ extern char *argv0;
 void parse_shell_args(int argc, char **argv)
 {
 
-    /* Only checks for -- arguments */
+    /* Only checks for -- options */
     int i;
     for (i = 0; i < argc; i++)
     {
         if (strcmp(argv[i], "--version") == 0)
             print_version_exit();
+        if (strcmp(argv[i], "--help") == 0)
+            print_help_info();
         if (strcmp(argv[i], "--verbose") == 0)
         {
             VerbosE = 1;
@@ -75,6 +78,17 @@ void parse_shell_args(int argc, char **argv)
                 break;
         }
     }
+}
+
+static void print_help_info()
+{
+    puts(
+        "-v --verbose enables verbose mode\n"
+        "--help shows this text\n"
+        "--version displays the version"
+        );
+   
+    exit_psh(0);
 }
 
 static void print_version_exit()

--- a/src/args.c
+++ b/src/args.c
@@ -83,6 +83,8 @@ void parse_shell_args(int argc, char **argv)
 static void print_help_info()
 {
     puts(
+        "Psh is a shell licensed under the GPLv3\n\n"
+        "OPTIONS\n"
         "-v --verbose enables verbose mode\n"
         "--help shows this text\n"
         "--version displays the version"

--- a/src/args.c
+++ b/src/args.c
@@ -1,5 +1,5 @@
 /*
-    psh/src/args.c - psh argument control
+    psh/args.c - psh argument parser
     Copyright 2020 Manuel Bertele
 
     This file is part of Psh, P shell.
@@ -23,10 +23,10 @@
 #include "psh.h"
 #include "util.h"
 
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
-void print_version_exit();
+static void print_version_exit();
 
 /* Set variable thats globally avaliable */
 int VerbosE = 0;
@@ -37,21 +37,22 @@ void parse_shell_args(int argc, char **argv)
 {
 
     /* Only checks for -- arguments */
-    short i;
-    for(i = 0; i < argc; i++)
+    int i;
+    for (i = 0; i < argc; i++)
     {
-        if(strcmp(argv[i], "--version") == 0)
+        if (strcmp(argv[i], "--version") == 0)
             print_version_exit();
-        if(strcmp(argv[i], "--verbose") == 0){
+        if (strcmp(argv[i], "--verbose") == 0)
+        {
             VerbosE = 1;
             argv[i][0] = '\0';
         }
-        else if (strstr(argv[i], "--") != NULL){
+        else if (strstr(argv[i], "--") != NULL)
+        {
             OUT2E("%s: unknown option %s\n", argv0, argv[i]);
             argv[i][0] = '\0';
         }
     }
-
 
     int arg;
     const char *optstring = ":v";
@@ -76,10 +77,8 @@ void parse_shell_args(int argc, char **argv)
     }
 }
 
-void print_version_exit()
+static void print_version_exit()
 {
-
-    puts("psh version: "PSH_VERSION);
+    puts("psh version: " PSH_VERSION);
     exit_psh(0);
-
 }

--- a/src/args.c
+++ b/src/args.c
@@ -22,7 +22,7 @@
 #include "libpsh/util.h"
 
 /* Set variable thats globally avaliable */
-int verbose = 0;
+int VerbosE = 0;
 extern int optopt;
 extern char *argv0;
 
@@ -38,7 +38,7 @@ void parse_shell_args(int argc, char **argv)
         {
             /* Verbose flag */
             case 'v':
-                verbose = 1;
+                VerbosE = 1;
                 break;
             case ':':
                 OUT2E("%s: option requires an argument\n", argv0);

--- a/src/args.c
+++ b/src/args.c
@@ -1,3 +1,23 @@
+/*
+    psh/src/args.c - psh argument control
+    Copyright 2020 Manuel Bertele
+
+    This file is part of Psh, P shell.
+
+    Psh is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Psh is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include "backend.h"
 #include "libpsh/util.h"
 

--- a/src/args.c
+++ b/src/args.c
@@ -12,7 +12,7 @@ void setargs(int argc, char **argv, const char *optstring, char *argv0)
     int arg;
 
     /* Parse shell options */
-    while ((arg = psh_backend_getopt(argc, argv, ":v")) != -1)
+    while ((arg = psh_backend_getopt(argc, argv, optstring)) != -1)
     {
         switch (arg)
         {

--- a/src/args.c
+++ b/src/args.c
@@ -1,6 +1,7 @@
 /*
     psh/args.c - psh argument parser
     Copyright 2020 Manuel Bertele
+    Copyright 2020 Zhang Maiyun
 
     This file is part of Psh, P shell.
 
@@ -41,19 +42,25 @@ void parse_shell_args(int argc, char **argv)
     int i;
     for (i = 0; i < argc; i++)
     {
+        if (strcmp(argv[i], "--") == 0)
+            break;
         if (strcmp(argv[i], "--version") == 0)
             print_version_exit();
         if (strcmp(argv[i], "--help") == 0)
+        {
             print_help_info();
+            exit_psh(0);
+        }
         if (strcmp(argv[i], "--verbose") == 0)
         {
             VerbosE = 1;
             argv[i][0] = '\0';
         }
-        else if (strstr(argv[i], "--") != NULL)
+        else if (strstr(argv[i], "--") == argv[i])
         {
+            print_help_info();
             OUT2E("%s: unknown option %s\n", argv0, argv[i]);
-            argv[i][0] = '\0';
+            exit_psh(2);
         }
     }
 
@@ -71,26 +78,29 @@ void parse_shell_args(int argc, char **argv)
                 break;
             case ':':
                 OUT2E("%s: option requires an argument\n", argv0);
-                break;
+                exit_psh(1);
             case '?':
             default:
+                print_help_info();
                 OUT2E("%s: unknown option -%c\n", argv0, optopt);
-                break;
+                exit_psh(2);
         }
     }
 }
 
 static void print_help_info()
 {
-    puts(
-        "Psh is a shell licensed under the GPLv3\n\n"
-        "OPTIONS\n"
-        "-v --verbose enables verbose mode\n"
-        "--help shows this text\n"
-        "--version displays the version"
-        );
-   
-    exit_psh(0);
+    printf("psh, version " PSH_VERSION "\n"
+           "Copyright (C) 2017-2020 Zhang Maiyun, Manuel Bertele\n"
+           "This program comes with ABSOLUTELY NO WARRANTY.\n"
+           "This is free software, and you are welcome to redistribute it\n"
+           "under certain conditions.\n\n"
+           "Usage: %s [options]\n"
+           "Options:\n"
+           "\t-v, --verbose: Enable verbose mode\n"
+           "\t--help: Show this text and exit\n"
+           "\t--version: Print psh version and exit\n",
+           argv0);
 }
 
 static void print_version_exit()

--- a/src/args.c
+++ b/src/args.c
@@ -1,15 +1,15 @@
-#include <unistd.h>
-
-#include "libpsh/util.h"
 #include "backend.h"
+#include "libpsh/util.h"
 
 /* Set variable thats globally avaliable */
 int verbose = 0;
+extern int optopt;
+extern char *argv0;
 
-void setargs(int argc, char **argv, const char *optstring, char *argv0)
+void parse_shell_args(int argc, char **argv)
 {
-
     int arg;
+    const char *optstring = ":v";
 
     /* Parse shell options */
     while ((arg = psh_backend_getopt(argc, argv, optstring)) != -1)
@@ -29,5 +29,4 @@ void setargs(int argc, char **argv, const char *optstring, char *argv0)
                 break;
         }
     }
-
 }

--- a/src/args.c
+++ b/src/args.c
@@ -21,6 +21,7 @@
 #include "backend.h"
 #include "libpsh/util.h"
 #include "psh.h"
+#include "util.h"
 
 #include <string.h>
 #include <stdlib.h>
@@ -41,6 +42,14 @@ void parse_shell_args(int argc, char **argv)
     {
         if(strcmp(argv[i], "--version") == 0)
             print_version_exit();
+        if(strcmp(argv[i], "--verbose") == 0){
+            VerbosE = 1;
+            argv[i][0] = '\0';
+        }
+        else if (strstr(argv[i], "--") != NULL){
+            OUT2E("%s: unknown option %s\n", argv0, argv[i]);
+            argv[i][0] = '\0';
+        }
     }
 
 
@@ -71,6 +80,6 @@ void print_version_exit()
 {
 
     puts("psh version: "PSH_VERSION);
-    exit(0);
+    exit_psh(0);
 
 }

--- a/src/args.c
+++ b/src/args.c
@@ -20,6 +20,12 @@
 
 #include "backend.h"
 #include "libpsh/util.h"
+#include "psh.h"
+
+#include <string.h>
+#include <stdlib.h>
+
+void print_version_exit();
 
 /* Set variable thats globally avaliable */
 int VerbosE = 0;
@@ -28,6 +34,16 @@ extern char *argv0;
 
 void parse_shell_args(int argc, char **argv)
 {
+
+    /* Only checks for -- arguments */
+    short i;
+    for(i = 0; i < argc; i++)
+    {
+        if(strcmp(argv[i], "--version") == 0)
+            print_version_exit();
+    }
+
+
     int arg;
     const char *optstring = ":v";
 
@@ -49,4 +65,12 @@ void parse_shell_args(int argc, char **argv)
                 break;
         }
     }
+}
+
+void print_version_exit()
+{
+
+    puts("psh version: "PSH_VERSION);
+    exit(0);
+
 }

--- a/src/backends/posix/posix.c
+++ b/src/backends/posix/posix.c
@@ -184,10 +184,10 @@ int psh_backend_do_run(struct command *arginfo)
 {
     struct command *info = arginfo;
 
-    extern int verbose;
+    extern int VerbosE;
 
-    /* verbose can be 0 or 1, if is only true when verbose == 1 */
-    if (verbose)
+    /* VerbosE can be 0 or 1, if is only true when verbose == 1 */
+    if (VerbosE)
     {
         int i = 0;
         printf("--**--\nstub!\nflags won't be read\n");

--- a/src/backends/posix/posix.c
+++ b/src/backends/posix/posix.c
@@ -180,9 +180,11 @@ static int redir_spawnve(struct redirect *arginfo, char *cmd, char **argv,
     return pid;
 }
 
-int psh_backend_do_run(struct command *arginfo, char verbose)
+int psh_backend_do_run(struct command *arginfo)
 {
     struct command *info = arginfo;
+
+    extern int verbose;
 
     /* verbose can be 0 or 1, if is only true when verbose == 1 */
     if (verbose)

--- a/src/main.c
+++ b/src/main.c
@@ -56,7 +56,9 @@ int main(int argc, char **argv)
     int arg;
     int verbose = 0;
 
-    argv0 = psh_strdup((strrchr(argv[0], '/') == NULL ? argv[0] : strrchr(argv[0], '/') + 1));
+	/* TODO: Store this as shell arguments */
+    argv0 = psh_strdup(
+			(strrchr(argv[0], '/') == NULL ? argv[0] : strrchr(argv[0], '/') + 1));
 
     /* Parse shell options */
     while ((arg = psh_backend_getopt(argc, argv, ":v")) != -1)

--- a/src/main.c
+++ b/src/main.c
@@ -56,6 +56,8 @@ int main(int argc, char **argv)
     int arg;
     int verbose = 0;
 
+    argv0 = psh_strdup((strrchr(argv[0], '/') == NULL ? argv[0] : strrchr(argv[0], '/') + 1));
+
     /* Parse shell options */
     while ((arg = psh_backend_getopt(argc, argv, ":v")) != -1)
     {
@@ -74,10 +76,6 @@ int main(int argc, char **argv)
                 break;
         }
     }
-
-    /* TODO: Store this as shell arguments */
-    argv0 = psh_strdup(
-        (strrchr(argv[0], '/') == NULL ? argv[0] : strrchr(argv[0], '/') + 1));
 
     add_atexit_free(argv0);
 

--- a/src/main.c
+++ b/src/main.c
@@ -30,6 +30,7 @@
 #include <readline/history.h>
 #endif
 
+#include "args.h"
 #include "backend.h"
 #include "builtin.h"
 #include "command.h"
@@ -39,7 +40,6 @@
 #include "libpsh/xmalloc.h"
 #include "prompts.h"
 #include "util.h"
-#include "args.h"
 
 int last_command_status = 0; /* #8 TODO: $? */
 char *argv0;
@@ -57,10 +57,9 @@ int main(int argc, char **argv)
 
     /* TODO: Store this as shell arguments */
     argv0 = psh_strdup(
-			(strrchr(argv[0], '/') == NULL ? argv[0] : strrchr(argv[0], '/') + 1));
+        (strrchr(argv[0], '/') == NULL ? argv[0] : strrchr(argv[0], '/') + 1));
 
-    /* Sets the given parameters and gives them its values */
-    setargs(argc, argv, ":v", argv0);
+    parse_shell_args(argc, argv);
 
     add_atexit_free(argv0);
 

--- a/src/main.c
+++ b/src/main.c
@@ -39,6 +39,7 @@
 #include "libpsh/xmalloc.h"
 #include "prompts.h"
 #include "util.h"
+#include "args.h"
 
 int last_command_status = 0; /* #8 TODO: $? */
 char *argv0;
@@ -53,31 +54,13 @@ int main(int argc, char **argv)
     char *ps1 =
         "\\[\\e[01;32m\\]\\u \\D{} " /* #8 TODO: $PS1 */
         "\\[\\e[01;34m\\]\\w\\[\\e[01;35m\\]\\012\\s-\\V\\[\\e[0m\\]\\$ ";
-    int arg;
-    int verbose = 0;
 
-	/* TODO: Store this as shell arguments */
+    /* TODO: Store this as shell arguments */
     argv0 = psh_strdup(
 			(strrchr(argv[0], '/') == NULL ? argv[0] : strrchr(argv[0], '/') + 1));
 
-    /* Parse shell options */
-    while ((arg = psh_backend_getopt(argc, argv, ":v")) != -1)
-    {
-        switch (arg)
-        {
-            /* Verbose flag */
-            case 'v':
-                verbose = 1;
-                break;
-            case ':':
-                OUT2E("%s: option requires an argument\n", argv0);
-                break;
-            case '?':
-            default:
-                OUT2E("%s: unknown option -%c\n", argv0, optopt);
-                break;
-        }
-    }
+    /* Sets the given parameters and gives them its values */
+    setargs(argc, argv, ":v", argv0);
 
     add_atexit_free(argv0);
 
@@ -113,7 +96,7 @@ int main(int argc, char **argv)
         }
         else
         {
-            psh_backend_do_run(cmd, verbose);
+            psh_backend_do_run(cmd);
         }
         free_command(cmd);
     }


### PR DESCRIPTION
Hey,
I have found that a `(null)` is printed when a unknown option is given.
This pull request fixes this issiue by moving a `argv0` some lines up.

Thanks for the info of my misconfigured git, I think I fixed it now.

Regards,
Manuel