### PR TITLE
Implementation of -x flag

### DIFF
--- a/include/psh.h
+++ b/include/psh.h
@@ -67,5 +67,7 @@ typedef struct _psh_state
     unsigned int verbose : 1;
     /** Interactive flag. */
     unsigned int interactive : 1;
+    /** -x flag */
+    unsigned int trace : 1;
 } psh_state;
 #endif

--- a/src/args.c
+++ b/src/args.c
@@ -95,7 +95,8 @@ void parse_shell_args(psh_state *state, int argc, char **argv)
                     exit_psh(state, 1);
                 }
                 if (state->trace == 1)
-                    printf("+ %s", optarg);
+                    printf("+ %s\n", optarg);
+                fflush(stdout);
                 psh_backend_do_run(state, cmd);
                 free_command(cmd);
                 exit_psh(state, (int)psh_vf_getint(state, "?"));

--- a/src/args.c
+++ b/src/args.c
@@ -70,7 +70,7 @@ void parse_shell_args(psh_state *state, int argc, char **argv)
     }
 
     int arg;
-    const char *optstring = ":vic:";
+    const char *optstring = ":vixc:";
 
     /* Parse shell options */
     while ((arg = psh_backend_getopt(argc, argv, optstring)) != -1)
@@ -81,6 +81,10 @@ void parse_shell_args(psh_state *state, int argc, char **argv)
             case 'i':
                 state->interactive = 1;
                 break;
+            /* -x flag */
+            case 'x':
+                state->trace = 1;
+                break;
             /* -c flag */
             case 'c':
             {
@@ -90,6 +94,8 @@ void parse_shell_args(psh_state *state, int argc, char **argv)
                     free_command(cmd);
                     exit_psh(state, 1);
                 }
+                if (state->trace == 1)
+                    printf("+ %s", optarg);
                 psh_backend_do_run(state, cmd);
                 free_command(cmd);
                 exit_psh(state, (int)psh_vf_getint(state, "?"));

--- a/src/main.c
+++ b/src/main.c
@@ -113,7 +113,10 @@ int main(int argc, char **argv)
         if (stat < 0)
             continue;
         cmd = new_command();
-        stat = filpinfo(state, expand_alias(state, buffer), cmd);
+        char *expanded_aliases = expand_alias(state, buffer);
+        if (state->trace == 1)
+            printf("+ %s\n", expanded_aliases);
+        stat = filpinfo(state, expanded_aliases, cmd);
         xfree(buffer);
         if (stat < 0)
         {


### PR DESCRIPTION
This is not much code but it seems to work like bash's -x as far as I can test it.
The `fflush(stdout);` may seem a little useless but in some rare cases the `printf("+ %s\n", optarg);` is printed after the `psh_backend_do_run(state, cmd);`.